### PR TITLE
add check to CommonGF when using install command

### DIFF
--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -100,7 +100,9 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 		$this->save_key( $key );
 
-		$key = GFCommon::get_key();
+		if (class_exists('GFCommon')) {
+			$key = GFCommon::get_key();
+		}
 
 		$plugin_info = $this->get_plugin_info( $slug, $key );
 


### PR DESCRIPTION
When using gravityformscli to install gravity forms using

``` sh
$ wp gf install --key=XXXXXXXXXXX
```

an error gets thrown that `GFCommon` is not defined. This is because `GFCommon` is part of the main gravity forms plugin, which is not defined when installing gravity forms for the first time. 