### PR TITLE
Fix form update

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.0
+Version: 1.0.1
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-3.0+
@@ -28,7 +28,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 */
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.0' );
+define( 'GF_CLI_VERSION', '1.0.1' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-form.php
+++ b/includes/class-gf-cli-form.php
@@ -516,7 +516,7 @@ class GF_CLI_Form extends WP_CLI_Command {
 			$form = $form['0'];
 		}
 
-		$existing_form = GFAPI::get_form( $form );
+		$existing_form = GFAPI::get_form( $form_id );
 
 		if ( ! $existing_form ) {
 			WP_CLI::error( 'Form not found' );
@@ -540,7 +540,7 @@ class GF_CLI_Form extends WP_CLI_Command {
 		}
 
 		// Pass the form object to update_form and store the result
-		$result = GFAPI::update_form( $form );
+		$result = GFAPI::update_form( $form, $form_id );
 		if ( is_wp_error( $result ) ) {
 			// If there was an error, throw an error
 			WP_CLI::error( $result );

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,9 @@ https://www.gravityhelp.com/request-support/
 
 == ChangeLog ==
 
+= 1.0.1 =
+- Fixed the wp gf form update command using the wrong argument to get the existing form which could result in a form not found error.
+
 = 1.0 =
 - Added the wp gf license command.
 - Fixed an issue with updating forms from an export file.


### PR DESCRIPTION
re: [HS#217740](https://secure.helpscout.net/conversation/558980046/217740?folderId=5488)

Fix an issue where the id of the form to be updated is not being used to get the form. 

The `$form` is run through `absint` by `GFAPI::get_form` which results in the form id of 1 being used to retrieve the form. 

If a form with the id 1 does not exist the form update command returns the `Form not found` error.

If a form with the id 1 does exist `GFAPI::update_form` updates the correct form (not id 1) as it gets the id of the form to be updated from the `$form['id']`.