### PR TITLE
Fix field update property parameter

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.0.1
+Version: 1.0.2
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-3.0+
@@ -11,7 +11,7 @@ Text Domain: gravityformscli
 Domain Path: /languages
 
 ------------------------------------------------------------------------
-Copyright 2016-2017 Rocketgenius, Inc.
+Copyright 2016-2018 Rocketgenius, Inc.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 */
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.0.1' );
+define( 'GF_CLI_VERSION', '1.0.2' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-form-field.php
+++ b/includes/class-gf-cli-form-field.php
@@ -228,7 +228,7 @@ class GF_CLI_Form_Field extends WP_CLI_Command {
 	 * <field-id>
 	 * : The field ID
 	 *
-	 * [--<field-property>=<field-value>]
+	 * [--<property>=<value>]
 	 * : The field properties to update
 	 *
 	 * [--field-json=<field-json>]
@@ -238,7 +238,7 @@ class GF_CLI_Form_Field extends WP_CLI_Command {
 	 *
 	 *     wp gf update 1 2 --type='text' --label='My Field'
 	 *
-	 * @synopsis <form-id> <field-id> [--<field-property>=<field-value>] [--field-json=<field-json>]
+	 * @synopsis <form-id> <field-id> [--<property>=<value>] [--field-json=<field-json>]
 	 */
 	public function update( $args, $assoc_args ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,9 @@ https://www.gravityforms.com/open-support-ticket/
 
 == ChangeLog ==
 
+= 1.0.2 =
+- Fixed an "invalid synopsis part" warning and an "unknown parameter" error with the wp gf form field update command.
+
 = 1.0.1 =
 - Fixed the wp gf form update command using the wrong argument to get the existing form which could result in a form not found error.
 


### PR DESCRIPTION
When using `--field-json` the field updated but also returned a warning with the success message.

>Warning: The \`wp gf form field update\` command has an invalid synopsis part: `[--<field-property>=<field-value>]`

Using `wp gf form field update 14 2 --visibility=visible` returned a parameter error: 

> unknown --visibility parameter

Changing `[--<field-property>=<field-value>]` to `[--<property>=<value>]` resolved both issues.