### PR TITLE
Fix remote message remaining after key change

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.0.2
+Version: 1.0.3
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-3.0+
@@ -28,7 +28,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 */
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.0.2' );
+define( 'GF_CLI_VERSION', '1.0.3' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-license.php
+++ b/includes/class-gf-cli-license.php
@@ -33,10 +33,6 @@ class GF_CLI_License extends WP_CLI_Command {
 
 		$this->save_key( $key );
 
-		if ( class_exists( 'GFCommon' ) ) {
-			GFCommon::get_version_info( false );
-		}
-
 		WP_CLI::log( 'License key updated' );
 	}
 
@@ -54,13 +50,14 @@ class GF_CLI_License extends WP_CLI_Command {
 
 		$this->save_key( '' );
 
-		if ( class_exists( 'GFCommon' ) ) {
-			GFCommon::get_version_info( false );
-		}
-
 		WP_CLI::log( 'License key deleted' );
 	}
 
+	/**
+	 * Saves or deletes the license key from the database.
+	 *
+	 * @param string $key The license key to be saved.
+	 */
 	private function save_key( $key ) {
 		$current_key = get_option( 'rg_gforms_key' );
 		if ( empty( $key ) ) {
@@ -68,6 +65,22 @@ class GF_CLI_License extends WP_CLI_Command {
 		} else if ( $current_key != $key ) {
 			$key = trim( $key );
 			update_option( 'rg_gforms_key', md5( $key ) );
+		}
+
+		$this->maybe_update_caches();
+	}
+
+	/**
+	 * Refreshes cached data which could become invalid after changing the license key.
+	 *
+	 * @since 1.0.3
+	 */
+	private function maybe_update_caches() {
+		if ( class_exists( 'GFCommon' ) ) {
+			// Update the contents of the gform_version_info option.
+			GFCommon::get_version_info( false );
+			// Update the contents of the rg_gforms_message option.
+			GFCommon::cache_remote_message();
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,9 @@ https://www.gravityforms.com/open-support-ticket/
 
 == ChangeLog ==
 
+= 1.0.3 =
+- Fixed an issue where old messages could continue to be displayed in the admin following a license key change.
+
 = 1.0.2 =
 - Fixed an "invalid synopsis part" warning and an "unknown parameter" error with the wp gf form field update command.
 


### PR DESCRIPTION
re: [HS#217464](https://secure.helpscout.net/conversation/557418314/217464/?folderId=5488)

Fixes the unlicensed copy notice remaining after updating the license key.