### PR TITLE
Rc 1.0.4

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.0.3
+Version: 1.0.4
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-3.0+
@@ -28,9 +28,9 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 */
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.0.3' );
+define( 'GF_CLI_VERSION', '1.0.4' );
 
-define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
+define( 'GF_CLI_MIN_GF_VERSION', '2.3.6.5' );
 
 add_action( 'init', array( 'GF_CLI_Bootstrap', 'load_cli' ), 1 );
 

--- a/cli.php
+++ b/cli.php
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 // Defines the current version of the CLI add-on
 define( 'GF_CLI_VERSION', '1.0.4' );
 
-define( 'GF_CLI_MIN_GF_VERSION', '2.3.6.5' );
+define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 
 add_action( 'init', array( 'GF_CLI_Bootstrap', 'load_cli' ), 1 );
 

--- a/includes/class-gf-cli-entry.php
+++ b/includes/class-gf-cli-entry.php
@@ -508,7 +508,6 @@ class GF_CLI_Entry extends WP_CLI_Command {
 
 		//Set search_criteria
 		$search_criteria['status']        = 'active';
-		// Check if date flag is set
 		// Check to see if start date and end date are set to add to search_criteria
 		if ( isset ( $assoc_args['startdate'] ) ) {
 			$search_criteria['start_date'] = $assoc_args['startdate'];
@@ -939,7 +938,12 @@ class GF_CLI_Entry extends WP_CLI_Command {
 
 		$progress = WP_CLI\Utils\make_progress_bar( sprintf( 'Exporting %d entries', $entry_count ), $entry_count );
 		do {
-			$status = GFExport::start_export( $form , $offset, $export_id, $search_criteria );
+			//If start_date is not set, no criteria is used. For backward compatibility with GravityForms.
+			if( isset( $search_criteria['start_date'] )) {
+				$status = GFExport::start_export( $form , $offset, $export_id, $search_criteria );
+			} else {
+				$status = GFExport::start_export( $form , $offset, $export_id );
+			}
 			$offset = $status['offset'];
 			$progress_limit = $offset == 0 ? $entry_count : $offset;
 			for ( $i = 0; $i < $progress_limit; $i++ ) {


### PR DESCRIPTION
Description:
Update gravityformscli plugin to allow startdate and enddate parameters for filtering entry export for both CSV and JSON format.

Note:
GravityForms export.php must be updated at line 688 to allow start_export() function to accept search_criteria parameter for CSV export to work. JSON export will work without modifications to base Gravity Forms plugin.