### PR TITLE
Fix error message on gf install

### DIFF
--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -149,13 +149,6 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 			WP_CLI::runcommand( $command, $options );
 
-			if ( $activate ) {
-				$setup_command = 'gf setup ' . $slug;
-				if ( $force ) {
-					$setup_command .= ' --force';
-				}
-				WP_CLI::runcommand( $setup_command, $options );
-			}
 		} else {
 			WP_CLI::error( 'There was a problem retrieving the download URL, please check the key.' );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: rocketgenius, stevehenty
 Tags: gravity forms
 Requires at least: 4.2
-Tested up to: 4.9.5
+Tested up to: 4.9.8
 Stable tag: trunk
 License: GPL-3.0+
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -180,6 +180,10 @@ https://www.gravityforms.com/open-support-ticket/
 1.  Go to the Plugin management page of WordPress admin section and enable the 'Gravity Forms CLI' plugin
 
 == ChangeLog ==
+
+
+= 1.0.4 =
+- Fixed an issue with the "wp gf install" command ending with an error message when no error occurred.
 
 = 1.0.3 =
 - Added the "wp gf tool system-report" command and the "wp gf tool status" alias for outputting the system report from the Gravity Forms 2.2+ System Status page.


### PR DESCRIPTION
This PR fixes an error message displayed when Gravity Forms is installed using the "wp gf install" command. Since Gravity Forms 2.3 the set up is now handled automatically on plugin activation.

Addresses [HS232385](https://secure.helpscout.net/conversation/660711788/232385?folderId=29193)

**Testing instructions**
On master, use the `wp gf install --key=xxxxx --activate` command to install Gravity Forms. Notice the "Error: Use the --force flag to force the database setup." message. Check with this branch that the error message is not displayed but the installation and set up is complete.
