### PR TITLE
Fix missing field IDs when creating a form

### DIFF
--- a/includes/class-gf-cli-form.php
+++ b/includes/class-gf-cli-form.php
@@ -241,6 +241,21 @@ class GF_CLI_Form extends WP_CLI_Command {
 			if ( isset( $args[1] ) ) {
 				$form['description'] = $args[1];
 			}
+
+			if ( ! isset( $form['fields'] ) ) {
+				$form['fields'] = array();
+			}
+
+			$field_ids = wp_list_pluck( $form['fields'], 'id' );
+			var_dump( $field_ids );
+			$field_ids = array_map( 'absint', $field_ids );
+			$next_field_id = max( $field_ids ) + 1;
+			foreach( $form['fields'] as &$field ) {
+				if ( ! isset( $field['id'] ) ) {
+					$field['id'] = $next_field_id++;
+				}
+			}
+
 		} else {
 			// Set the title based on the passed argument
 			$title       = $args[0];

--- a/includes/class-gf-cli-form.php
+++ b/includes/class-gf-cli-form.php
@@ -247,7 +247,6 @@ class GF_CLI_Form extends WP_CLI_Command {
 			}
 
 			$field_ids = wp_list_pluck( $form['fields'], 'id' );
-			var_dump( $field_ids );
 			$field_ids = array_map( 'absint', $field_ids );
 			$next_field_id = max( $field_ids ) + 1;
 			foreach( $form['fields'] as &$field ) {


### PR DESCRIPTION
This PR adds IDs to fields if the ID is missing when creating a form using the `wp gf form create` command. Missing field IDs generate errors in the form editor and display.

Addresses issue #11

**Testing instructions**
To reproduce the issue on master create a form with the following command. Notice the fields are missing IDs.

`wp gf form create --form-json='{ "title": "test", "description": "", "labelPlacement": "top_label", "descriptionPlacement": "below", "button": { "type": "text", "text": "Submit", "imageUrl": "" }, "fields": [ { "type": "text", "label": "Untitled", "adminLabel": "", "isRequired": false, "size": "medium", "errorMessage": "", "visibility": "visible", "inputs": null, "formId": 1, "description": "", "allowsPrepopulate": false, "inputMask": false, "inputMaskValue": "", "inputType": "", "labelPlacement": "", "descriptionPlacement": "", "subLabelPlacement": "", "placeholder": "", "cssClass": "", "inputName": "", "noDuplicates": false, "defaultValue": "", "choices": "", "conditionalLogic": "", "productField": "", "enablePasswordInput": "", "maxLength": "", "pageNumber": 1 }, { "type": "textarea", "label": "Untitled", "adminLabel": "", "isRequired": false, "size": "medium", "errorMessage": "", "visibility": "visible", "inputs": null, "formId": 1, "description": "", "allowsPrepopulate": false, "inputMask": false, "inputMaskValue": "", "inputType": "", "labelPlacement": "", "descriptionPlacement": "", "subLabelPlacement": "", "placeholder": "", "cssClass": "", "inputName": "", "noDuplicates": false, "defaultValue": "", "choices": "", "conditionalLogic": "", "productField": "", "form_id": "", "useRichTextEditor": "", "pageNumber": 1 } ] }'`

On this branch the fields are assigned IDs before creating the form.

