### PR TITLE
Fix field property updates

### DIFF
--- a/includes/class-gf-cli-form-field.php
+++ b/includes/class-gf-cli-form-field.php
@@ -289,7 +289,6 @@ class GF_CLI_Form_Field extends WP_CLI_Command {
 				$field['label'] = __( 'Untitled', 'gravityforms' );
 			}
 		} else {
-
 			// Get the property/value for the update data
 			foreach ( $assoc_args as $field_property => $value ) {
 				// If the field property is the form ID, skip it

--- a/includes/class-gf-cli-form-field.php
+++ b/includes/class-gf-cli-form-field.php
@@ -228,7 +228,7 @@ class GF_CLI_Form_Field extends WP_CLI_Command {
 	 * <field-id>
 	 * : The field ID
 	 *
-	 * [--<property>=<value>]
+	 * [--<field>=<value>]
 	 * : The field properties to update
 	 *
 	 * [--field-json=<field-json>]
@@ -238,7 +238,7 @@ class GF_CLI_Form_Field extends WP_CLI_Command {
 	 *
 	 *     wp gf update 1 2 --type='text' --label='My Field'
 	 *
-	 * @synopsis <form-id> <field-id> [--<property>=<value>] [--field-json=<field-json>]
+	 * @synopsis <form-id> <field-id> [--<field>=<value>] [--field-json=<field-json>]
 	 */
 	public function update( $args, $assoc_args ) {
 
@@ -289,6 +289,7 @@ class GF_CLI_Form_Field extends WP_CLI_Command {
 				$field['label'] = __( 'Untitled', 'gravityforms' );
 			}
 		} else {
+
 			// Get the property/value for the update data
 			foreach ( $assoc_args as $field_property => $value ) {
 				// If the field property is the form ID, skip it


### PR DESCRIPTION
This PR fixes an issue with the `wp gf field update` command where arbitrary properties/value pairs are not accepted by the command.

Fixes [HS236084](https://secure.helpscout.net/conversation/691307996/236084/?folderId=29193)

**Testing instructions**
To reproduce the issue on master use the `wp gf field update` command to update a field property. E.g.
`wp gf field update 18 1 --label="test2"`
The following error will be displayed and the command will not be run:
```
Warning: The `wp gf field update` command has an invalid synopsis part: [--<property>=<value>]
Error: Parameter errors:
 unknown --label parameter
```
On this branch the update will be successful:
`Success: Field ID: 1 updated`

