### PR TITLE
Fix entry export status

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,6 @@ Requirements
 Support
 -------
 
-If you find any that needs fixing, or if you have any ideas for improvements, please submit a support ticket:
+If you find anything that needs fixing, or if you have any ideas for improvements, please open a support ticket:
 https://www.gravityforms.com/open-support-ticket/
 

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.1
+Version: 1.1.1
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.1' );
+define( 'GF_CLI_VERSION', '1.1.1' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-entry.php
+++ b/includes/class-gf-cli-entry.php
@@ -451,10 +451,6 @@ class GF_CLI_Entry extends WP_CLI_Command {
 	 * [--dir=<dir>]
 	 * : The directory to write the file. Defaults to the current working directory.
 	 *
-	 * [--status=<status>]
-	 * : The status of the entries. Default: active
-	 * Accepted values: trash, active
-	 *
 	 * Examples
 	 *      --filename=entries.json
 	 *      --filename=entries.csv
@@ -465,7 +461,7 @@ class GF_CLI_Entry extends WP_CLI_Command {
 	 *     wp gf entry export 1 --format=json
 	 *     wp gf entry export 1 --format=csv --start_date="2018-01-01" --end_date="2018-03-25"
 	 *
-	 * @synopsis <form-id> [<filename>] [--dir=<dir>] [--format=<format>] [--start_date=<yyyy-mm-dd>] [--end_date=<yyyy-mm-dd>] [--status=<status>]
+	 * @synopsis <form-id> [<filename>] [--dir=<dir>] [--format=<format>] [--start_date=<yyyy-mm-dd>] [--end_date=<yyyy-mm-dd>]
 	 */
 	public function export( $args, $assoc_args ) {
 		// Check is the form ID was defined.
@@ -512,14 +508,7 @@ class GF_CLI_Entry extends WP_CLI_Command {
 			}
 		}
 
-		// Default entry status to active if no status flag is set.
-		if ( ! isset( $assoc_args['status'] ) ) {
-			$assoc_args['status'] = 'active';
-		}
-
 		$search_criteria = array();
-
-		$search_criteria['status'] = $assoc_args['status'];
 
 		// Check to see if start date and end date are set to add to search_criteria
 		if ( isset ( $assoc_args['start_date'] ) ) {
@@ -941,6 +930,8 @@ class GF_CLI_Entry extends WP_CLI_Command {
 		}
 
 		$_POST['export_field'] = $fields;
+
+		$search_criteria['status'] = 'status';
 
 		if ( isset( $search_criteria['start_date'] ) ) {
 			$_POST['export_date_start'] = $search_criteria['start_date'];

--- a/includes/class-gf-cli-entry.php
+++ b/includes/class-gf-cli-entry.php
@@ -451,6 +451,10 @@ class GF_CLI_Entry extends WP_CLI_Command {
 	 * [--dir=<dir>]
 	 * : The directory to write the file. Defaults to the current working directory.
 	 *
+	 * [--status=<status>]
+	 * : The status of the entries. Default: active
+	 * Accepted values: trash, active
+	 *
 	 * Examples
 	 *      --filename=entries.json
 	 *      --filename=entries.csv
@@ -461,7 +465,7 @@ class GF_CLI_Entry extends WP_CLI_Command {
 	 *     wp gf entry export 1 --format=json
 	 *     wp gf entry export 1 --format=csv --start_date="2018-01-01" --end_date="2018-03-25"
 	 *
-	 * @synopsis <form-id> [<filename>] [--dir=<dir>] [--format=<format>] [--start_date=<yyyy-mm-dd>] [--end_date=<yyyy-mm-dd>]
+	 * @synopsis <form-id> [<filename>] [--dir=<dir>] [--format=<format>] [--start_date=<yyyy-mm-dd>] [--end_date=<yyyy-mm-dd>] [--status=<status>]
 	 */
 	public function export( $args, $assoc_args ) {
 		// Check is the form ID was defined.
@@ -508,7 +512,14 @@ class GF_CLI_Entry extends WP_CLI_Command {
 			}
 		}
 
+		// Default entry status to active if no status flag is set.
+		if ( ! isset( $assoc_args['status'] ) ) {
+			$assoc_args['status'] = 'active';
+		}
+
 		$search_criteria = array();
+
+		$search_criteria['status'] = $assoc_args['status'];
 
 		// Check to see if start date and end date are set to add to search_criteria
 		if ( isset ( $assoc_args['start_date'] ) ) {
@@ -930,8 +941,6 @@ class GF_CLI_Entry extends WP_CLI_Command {
 		}
 
 		$_POST['export_field'] = $fields;
-
-		$search_criteria['status'] = 'status';
 
 		if ( isset( $search_criteria['start_date'] ) ) {
 			$_POST['export_date_start'] = $search_criteria['start_date'];

--- a/includes/class-gf-cli-entry.php
+++ b/includes/class-gf-cli-entry.php
@@ -931,7 +931,7 @@ class GF_CLI_Entry extends WP_CLI_Command {
 
 		$_POST['export_field'] = $fields;
 
-		$search_criteria['status'] = 'status';
+		$search_criteria['status'] = 'active';
 
 		if ( isset( $search_criteria['start_date'] ) ) {
 			$_POST['export_date_start'] = $search_criteria['start_date'];


### PR DESCRIPTION
RE: [HS #263011](https://secure.helpscout.net/conversation/910586289/263011?folderId=2752516)

Currently when exporting entries to a CSV via the CLI add-on the status will be listed as "Exporting 0 entries" regardless of the amount of entries a form has. This branch fixes an issue where the entry status was always set to "status" rather than a valid status.

### Testing Instructions
- Create a form and submit it a few times to create entires. You could also use an existing form that has entires.
- Run the following command subbing FORMID for your form's ID:
`wp gf entry export FORMID`
- Notice that despite the number of entries present on the form, "Exporting 0 entries" will be output next to the progress bar while exporting entries.
- Check the contents of the CSV file created, notice the correct data and amount of entries are present.
- Switch to this branch
- Run the command from above again and notice the correct amount of entries are output to the status text and if you check the created CSV file the data within is the same as master.