### PR TITLE
Update Gravity API domain

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.1.3
+Version: 1.1.4
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.1.3' );
+define( 'GF_CLI_VERSION', '1.1.4' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -364,7 +364,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 	private function get_plugin_info( $slug, $key = '' ) {
 
-		$gravity_manager_url = defined( 'GRAVITY_MANAGER_URL' ) && GRAVITY_MANAGER_URL ? GRAVITY_MANAGER_URL : 'https://www.gravityhelp.com/wp-content/plugins/gravitymanager';
+		$gravity_manager_url = defined( 'GRAVITY_MANAGER_URL' ) && GRAVITY_MANAGER_URL ? GRAVITY_MANAGER_URL : 'https://www.gravityapi.com/wp-content/plugins/gravitymanager';
 
 		$url      = $gravity_manager_url . "/api.php?op=get_plugin&slug={$slug}&key={$key}";
 		$options  = array(

--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,9 @@ https://www.gravityforms.com/open-support-ticket/
 
 == ChangeLog ==
 
+= 1.1.4 =
+- Updated Gravity API domain.
+
 = 1.1.3 =
 - Fixed an issue where the install command could not network activate plugins.
 


### PR DESCRIPTION
This PR updates Gravity API URL to use the `www.gravityapi.com` domain.

## Testing instructions
1. Activate the Gravity Forms Cli plugin. If you use Local by Flywheel, it already has WPCli installed, or you'll have to install WPCli on your server.
2. Add `define( 'GRAVITY_MANAGER_URL', 'https://dev.gravityhelp.com/wp-content/plugins/gravitymanager' );` to your `wp-config.php` file.
3. In the Local app, right-click on your site and click on "Open Site SSH" (https://d.pr/i/NK3RLO). Or ssh to your server.
4. Run the command `wp gf check_update` to see if you can get results.
5. Update the constant in `wp-config.php` to `https://dev.gravityapi.com/wp-content/plugins/gravitymanager`.
6. Repeat step 4.