### PR TITLE
Fixes an issue where gf form notification cannot get form_id

### DIFF
--- a/includes/class-gf-cli-form-notification.php
+++ b/includes/class-gf-cli-form-notification.php
@@ -422,7 +422,7 @@ class GF_CLI_Form_Notification extends WP_CLI_Command {
 
 		$found = false;
 		foreach ( $notifications as $key => $notification ) {
-			if ( $notification['id'] == $notification_id ) {
+      if ( $notification['id'] == $notification_id || $notification['id'] == $new_notification['id'] ) {
 				$notifications[ $key ] = $new_notification;
 				$found = true;
 				break;
@@ -489,7 +489,7 @@ class GF_CLI_Form_Notification extends WP_CLI_Command {
 
 	/**
 	 * Launches the editor, setting the content and title
-	 * 
+	 *
 	 * @since 1.0-beta-1
 	 * @access protected
 	 *


### PR DESCRIPTION
Submitting this PR -- I came across this before but $notification_id always comes back as NULL causing no form notifications to update

The use-case I'm using is scripting notifications to turn on/off based on an env and a bash script with the form ID and notification ID's being passed in

e.g.,
BASH FILE:
# functions
turn_off() {
  local turn_on=("${@:2}")
  local form_id=$1
  for id in "${turn_on[@]}"; do
    echo "Turning off: $id, $form_id"
    wp gf notification update ${form_id} --notification-json="$(wp gf notification get ${form_id} ${id} | sed "s/\"isActive\":true/\"isActive\":false/g")"
  done
}

Then I call the above function passing in the form id and an array of notification id's

Each time this occurs -- it gives the following error and $notification_id = NULL
"Notification not valid"
