### PR TITLE
Fix the notification-id arg for the form notification update command

### DIFF
--- a/includes/class-gf-cli-form-notification.php
+++ b/includes/class-gf-cli-form-notification.php
@@ -391,34 +391,47 @@ class GF_CLI_Form_Notification extends WP_CLI_Command {
 	 * <form-id>
 	 * : The Form ID
 	 *
+	 * [<notification-id>]
+	 * : The ID of the notification to updated.
+	 *
 	 * --notification-json=<notification-json>
-	 * : The JSON representation of the form
+	 * : The JSON representation of the notification.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp gf form notification update 1 --notification-json='{snip}'
+	 *     wp gf form notification update 1 abc1 --notification-json='{snip}'
 	 *
-	 * @synopsis <form-id> --notification-json=<notification-json>
+	 * @synopsis <form-id> [<notification-id>] --notification-json=<notification-json>
 	 */
 	function update( $args, $assoc_args ) {
 		$form_id = $args[0];
+		$form    = GFAPI::get_form( $form_id );
 
-		$notification_id = $args[1];
-
-		$form = GFAPI::get_form( $form_id );
 		if ( empty( $form ) ) {
 			WP_CLI::error( 'Form not found' );
 		}
 
-		$notifications = $form['notifications'];
-
-		$json_config = $assoc_args['notification-json'];
-
+		$json_config      = $assoc_args['notification-json'];
 		$new_notification = json_decode( $json_config, ARRAY_A );
 
 		if ( empty( $new_notification ) ) {
 			WP_CLI::error( 'Notification not valid' );
 		}
+
+		$notification_id = rgar( $args, 1 );
+
+		if ( empty( $notification_id ) ) {
+			if ( empty( $new_notification['id'] ) ) {
+				WP_CLI::error( 'Please specify the ID of the notification to be updated' );
+			} else {
+				$notification_id = $new_notification['id'];
+			}
+		} else {
+			$new_notification['id'] = $notification_id;
+		}
+
+		$notifications = $form['notifications'];
 
 		$found = false;
 		foreach ( $notifications as $key => $notification ) {


### PR DESCRIPTION
Supersedes #20 and #24 

Fixes a notice which occurs when using the command without including the `<notification-id>` arg.

```
[18-Nov-2019 10:50:42 UTC] PHP Notice:  Undefined offset: 1 in /app/public/wp-content/plugins/gravityformscli/includes/class-gf-cli-form-notification.php on line 406
[18-Nov-2019 10:50:42 UTC] PHP Stack trace:
[18-Nov-2019 10:50:42 UTC] PHP   1. {main}() /usr/local/bin/wp:0
[18-Nov-2019 10:50:42 UTC] PHP   2. include() /usr/local/bin/wp:4
[18-Nov-2019 10:50:42 UTC] PHP   3. include() phar:///usr/local/bin/wp/php/boot-phar.php:11
[18-Nov-2019 10:50:42 UTC] PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:27
[18-Nov-2019 10:50:42 UTC] PHP   5. WP_CLI\Bootstrap\LaunchRunner->process() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:74
[18-Nov-2019 10:50:42 UTC] PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23
[18-Nov-2019 10:50:42 UTC] PHP   7. WP_CLI\Runner->run_command_and_exit() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1132
[18-Nov-2019 10:50:42 UTC] PHP   8. WP_CLI\Runner->run_command() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:394
[18-Nov-2019 10:50:42 UTC] PHP   9. WP_CLI\Dispatcher\Subcommand->invoke() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:371
[18-Nov-2019 10:50:42 UTC] PHP  10. call_user_func:{phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451}() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451
[18-Nov-2019 10:50:42 UTC] PHP  11. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure:phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:95-102}() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451
[18-Nov-2019 10:50:42 UTC] PHP  12. call_user_func:{phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98}() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98
[18-Nov-2019 10:50:42 UTC] PHP  13. GF_CLI_Form_Notification->update() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98
```

## Testing Instructions

- Use the command without the `<notification-id>` arg e.g.
`wp gf form notification update 133 --notification-json='{"id":"5bacece91e2c9","to":"{admin_email}","name":"Admin Notification","event":"form_submission","toType":"email","subject":"New submission from {form_title}","message":"{all_fields}","isActive":false}'`
- Find `Error: Notification not found` is returned and the notice is recorded in the sites debug.log file
- Switch to this branch
- Repeat command and find `Success: Notification updated successfully` is returned
- Use the command with the `<notification-id>` arg e.g. `wp gf form notification update 133 5bacece91e2c9 --notification-json='{"to":"{admin_email}","name":"Admin Notification","event":"form_submission","toType":"email","subject":"New submission from {form_title}","message":"{all_fields}","isActive":true}'`
- Find `Success: Notification updated successfully` is returned
- Use the command without the `<notification-id>` arg and without passing the notification id in the json e.g. `wp gf form notification update 133 --notification-json='{"to":"{admin_email}","name":"Admin Notification","event":"form_submission","toType":"email","subject":"New submission from {form_title}","message":"{all_fields}","isActive":false}'`
- Find `Error: Please specify the ID of the notification to be updated` is returned