### PR TITLE
Fix network activate install flag

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: http://www.gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.1.2
+Version: 1.1.3
 Author: Rocketgenius
 Author URI: http://www.gravityforms.com
 License: GPL-2.0+
@@ -11,7 +11,7 @@ Text Domain: gravityformscli
 Domain Path: /languages
 
 ------------------------------------------------------------------------
-Copyright 2016-2019 Rocketgenius, Inc.
+Copyright 2016-2020 Rocketgenius, Inc.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.1.2' );
+define( 'GF_CLI_VERSION', '1.1.3' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -79,7 +79,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 * [--activate]
 	 * : If set, the plugin will be activated immediately after install.
 	 *
-	 * [--network-activate]
+	 * [--activate-network]
 	 * : If set, the plugin will be network activated immediately after install
 	 *
 	 *
@@ -89,7 +89,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 *     wp gf install --force
 	 *     wp gf install --key=[A valid Gravity Forms License Key]
 	 *     wp gf install gravityformspolls key=[1234ABC]
-	 * @synopsis [<slug>] [--key=<key>] [--version=<version>] [--force] [--activate] [--network-activate]
+	 * @synopsis [<slug>] [--key=<key>] [--version=<version>] [--force] [--activate] [--activate-network]
 	 */
 	public function install( $args, $assoc_args ) {
 		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
@@ -122,7 +122,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 			$activate = WP_CLI\Utils\get_flag_value( $assoc_args, 'activate', false );
 
-			$network_activate = WP_CLI\Utils\get_flag_value( $assoc_args, 'network-activate', false );
+			$activate_network = WP_CLI\Utils\get_flag_value( $assoc_args, 'activate-network', false );
 
 			$command = sprintf( 'plugin install "%s"', $download_url );
 
@@ -138,9 +138,9 @@ class GF_CLI_Root extends WP_CLI_Command {
 				$command .= ' --activate';
 			}
 
-			if ( $network_activate ) {
-				$install_assoc_args['network-activate'] = true;
-				$command .= ' --network-activate';
+			if ( $activate_network ) {
+				$install_assoc_args['activate-network'] = true;
+				$command .= ' --activate-network';
 			}
 
 			$options = array(

--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,9 @@ https://www.gravityforms.com/open-support-ticket/
 
 == ChangeLog ==
 
+= 1.1.3 =
+- Fixed an issue where the install command could not network activate plugins.
+
 = 1.1.2 =
 - Updated the ids format of the entry list command to support the page-size and offset args. Credit: Ulrich Pogson.
 - Updated the form export command to support the optional filename arg e.g. wp gf form export 1 --filename=testing.json. Credit: Timothy Decker.


### PR DESCRIPTION
RE: [HS #288035](https://secure.helpscout.net/conversation/1095496963/288035?folderId=2752516)

The wp gf install command does not use the correct WP CLI flag for network activating plugins on install. Currently we are using --network-activate [when the flag is actually --activate-network](https://developer.wordpress.org/cli/commands/plugin/install/), this leads to receiving the following error when used:

`Error: Parameter errors:
 unknown --network-activate parameter`

This PR updates the install command to use the correct flag.

## Testing Instructions
- Spin up a WP Multisite install and install WP CLI (if necessary, pre-installed on Local) and the CLI add-on by cloning the repo into your new installs plugins directory.
- Run the following command subbing XXXX for your GF license key:
`wp gf install --key=XXXX --network-activate`
- Find that you get the error listed above and no installation occurs.
- Switch to this branch
- Run the following command subbing XXXX for your GF license key:
`wp gf install --key=XXXX --activate-network`
- Refresh your list of network installed plugins and find that Gravity Forms is network installed.
- Run the following command subbing XXXX for your GF license key:
`wp gf install gravityformsmailchimp --key=XXXX --activate-network`
- Refresh your list of network installed plugins and find that the Mailchimp add-on is network installed.
- Run the following command subbing XXXX for your GF license key:
`wp gf install gravityformspolls --key=XXXX `
- Refresh your list of network installed plugins and find that the Polls add-on is installed, but not network activated.