### PR TITLE
Fix notification create command

### DIFF
--- a/includes/class-gf-cli-form-notification.php
+++ b/includes/class-gf-cli-form-notification.php
@@ -151,7 +151,7 @@ class GF_CLI_Form_Notification extends WP_CLI_Command {
 	 *     wp gf form notification create 1 "My Notification"
 	 *     wp gf form notification create 1 "My Notification" --to="admin@mysite.com"
 	 *
-	 * @synopsis [<title>] [<description>] [--form-json=<form-json>] [--porcelain]
+	 * @synopsis <form-id> [<name>] [--to=<to>] [--subject=<subject>] [--message=<message>] [--to-type=<to-type>] [--event=<event>] [--notification-json=<notification-json>] [--porcelain]
 	 */
 	function create( $args, $assoc_args ) {
 

--- a/includes/class-gf-cli-form-notification.php
+++ b/includes/class-gf-cli-form-notification.php
@@ -172,7 +172,7 @@ class GF_CLI_Form_Notification extends WP_CLI_Command {
 			$notification = json_decode( $notification_json, ARRAY_A );
 			// Check if the name had been set and override the JSON setting
 			if ( isset( $args[1] ) ) {
-				$notification['name'] = $args[0];
+				$notification['name'] = $args[1];
 			}
 
 			if ( ! isset( $notification['id'] ) || ( isset( $notification['id'] ) && isset( $notifications[ $notification['id'] ] ) ) ) {

--- a/includes/class-gf-cli-form-notification.php
+++ b/includes/class-gf-cli-form-notification.php
@@ -125,13 +125,13 @@ class GF_CLI_Form_Notification extends WP_CLI_Command {
 	 * [<name>]
 	 * : The name of the notification.
 	 *
-	 * <--to=<to>->
+	 * [--to=<to>]
 	 * : The to field. Default: {admin_email}
 	 *
-	 * <--subject=<subject>>
+	 * [--subject=<subject>]
 	 * : The subject field. Default: New submission from {form_title}
 	 *
-	 * <--message=<message>>
+	 * [--message=<message>]
 	 * : The message body. Default: {all_fields}
 	 *
 	 * [--to-type=<to-type>]


### PR DESCRIPTION
re: [HS#303986](https://secure.helpscout.net/conversation/1225740721/303986)

This fixes some issues with the docblock for the notification create command, the main being that the synopsis is for a different command so using the `--notification-json` option resulted in a parameter error.

Once the synopsis was fixed I noticed that the form id was assigned as the notification name instead of the value provided for the `name` option. This was fixed by getting the value from `$args[1]` instead of `$args[0]`.

## Testing Instructions
- With master enter `wp gf form notification create 1 'the name' --notification-json='{"subject":"the subject","message":"the message","from":"{admin_email}","fromName":"the from name"}'` replacing `1` with the ID of your test form
- Find a parameter error occurs
- Switch to this branch
- Repeat command
- Find notification is created and "the name" is assigned as the name of the notification