### PR TITLE
Update the install and update commands to support beta releases

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,6 @@
+= 1.3.1 =
+- Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.
+
 = 1.3 =
 - Fixed an error occurring when using the `wp gf form notification create` command.
 

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: https://gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.3
+Version: 1.3.1
 Author: Rocketgenius
 Author URI: https://gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.3' );
+define( 'GF_CLI_VERSION', '1.3.1' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -51,7 +51,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 			}
 
 			if ( ! $addon_found ) {
-				WP_CLI::error( 'Invalid pluging slug: ' . $slug );
+				WP_CLI::error( 'Invalid plugin slug: ' . $slug );
 			}
 		}
 	}

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -104,9 +104,13 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 		$key = md5( $key );
 
-		$plugin_info = $this->get_plugin_info( $slug, $key );
-
 		$version = isset( $assoc_args['version'] ) ? $assoc_args['version'] : 'hotfix';
+
+		if ( $version === 'beta' ) {
+			$slug .= '-beta';
+		}
+
+		$plugin_info = $this->get_plugin_info( $slug, $key );
 
 		if ( $version == 'hotfix' ) {
 			$download_url = isset( $plugin_info['download_url_latest'] ) ? $plugin_info['download_url_latest'] : '';
@@ -151,6 +155,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 			WP_CLI::runcommand( $command, $options );
 
+		} elseif ( $version === 'beta' ) {
+			WP_CLI::error( 'There is no beta release available at this time.' );
 		} else {
 			WP_CLI::error( 'There was a problem retrieving the download URL, please check the key.' );
 		}

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -29,7 +29,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 *     wp gf version gravityformspolls
 	 */
 	public function version( $args, $assoc_args ) {
-		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
+		$slug = $this->get_slug( $args );
 
 		if ( $slug == 'gravityforms' ) {
 			if ( class_exists( 'GFForms' ) ) {
@@ -92,9 +92,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 * @synopsis [<slug>] [--key=<key>] [--version=<version>] [--force] [--activate] [--activate-network]
 	 */
 	public function install( $args, $assoc_args ) {
-		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
-
-		$key = isset( $assoc_args['key'] ) ? $assoc_args['key'] : $key = $this->get_key();
+		$slug = $this->get_slug( $args, true );
+		$key  = isset( $assoc_args['key'] ) ? $assoc_args['key'] : $key = $this->get_key();
 
 		if ( empty( $key ) ) {
 			WP_CLI::error( 'A valid license key must be specified either in the GF_LICENSE_KEY constant or the --key option.' );
@@ -186,9 +185,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 			WP_CLI::error( 'Gravity Forms is not active.' );
 		}
 
-		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
-
-		$key = isset( $assoc_args['key'] ) ? $assoc_args['key'] : $key = $this->get_key();
+		$slug = $this->get_slug( $args, true );
+		$key  = isset( $assoc_args['key'] ) ? $assoc_args['key'] : $key = $this->get_key();
 
 		if ( empty( $key ) ) {
 			$key = GFCommon::get_key();
@@ -264,7 +262,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 */
 	public function setup( $args, $assoc_args ) {
 
-		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
+		$slug = $this->get_slug( $args );
 
 		$force = WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
@@ -319,7 +317,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 * @alias check-update
 	 */
 	public function check_update( $args, $assoc_args ) {
-		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
+		$slug = $this->get_slug( $args );
 
 		$plugin_info = $this->get_plugin_info( $slug );
 
@@ -412,6 +410,31 @@ class GF_CLI_Root extends WP_CLI_Command {
 		}
 
 		return $beta_info;
+	}
+
+	/**
+	 * Gets the plugin slug for the current command.
+	 *
+	 * @since 1.4
+	 *
+	 * @param array $args       The command arguments.
+	 * @param false $beta_check Should we check for the -beta suffix and display an error if found?
+	 *
+	 * @return string
+	 * @throws \WP_CLI\ExitException
+	 */
+	private function get_slug( $args, $beta_check = false ) {
+		if ( empty( $args[0] ) ) {
+			return 'gravityforms';
+		}
+
+		$slug = $args[0];
+
+		if ( $beta_check && strpos( $slug, '-beta' ) ) {
+			WP_CLI::error( 'Appending -beta to the slug is not supported. Use --version=beta instead.' );
+		}
+
+		return $slug;
 	}
 
 }

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -193,7 +193,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 			WP_CLI::error( 'Gravity Forms is not active.' );
 		}
 
-		$slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
+		$info_slug = $slug = isset( $args[0] ) ? $args[0] : 'gravityforms';
 
 		$key = isset( $assoc_args['key'] ) ? $assoc_args['key'] : $key = $this->get_key();
 
@@ -208,9 +208,13 @@ class GF_CLI_Root extends WP_CLI_Command {
 			WP_CLI::error( 'A valid license key must be saved in the settings or specified in the GF_LICENSE_KEY constant or the --key option.' );
 		}
 
-		$plugin_info = $this->get_plugin_info( $slug, $key );
-
 		$version = isset( $assoc_args['version'] ) ? $assoc_args['version'] : 'hotfix';
+
+		if ( $version === 'beta' ) {
+			$info_slug .= '-beta';
+		}
+
+		$plugin_info = $this->get_plugin_info( $info_slug, $key );
 
 		if ( $version == 'hotfix' ) {
 			$available_version = isset( $plugin_info['version_latest'] ) ? $plugin_info['version_latest'] : '';
@@ -243,6 +247,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 			WP_CLI::runcommand( $setup_command, $options );
 
+		} elseif ( $version === 'beta' ) {
+			WP_CLI::error( 'There is no beta release available at this time.' );
 		} else {
 			WP_CLI::error( 'There was a problem retrieving the download URL, please check the key.' );
 		}

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -71,7 +71,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 * : The license key if not already available in the GF_LICENSE_KEY constant.
 	 *
 	 * [--version=<version>]
-	 * : The version to be installed. Accepted values: auto-update, hotfix. Default: hotfix.
+	 * : The version to be installed. Accepted values: auto-update, hotfix, or beta. Default: hotfix.
 	 *
 	 * [--force]
 	 * : If set, the command will overwrite any installed version of the plugin, without prompting for confirmation.
@@ -170,7 +170,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 * : The license key if not already available in the GF_LICENSE_KEY constant.
 	 *
 	 * [--version=<version>]
-	 * : The version to be installed. Accepted values: auto-update, hotfix. Default: hotfix.
+	 * : The version to be installed. Accepted values: auto-update, hotfix, or beta. Default: hotfix.
 	 *
 	 *
 	 * ## EXAMPLES

--- a/readme.txt
+++ b/readme.txt
@@ -185,6 +185,9 @@ If you have any ideas for improvements please submit your idea at https://www.gr
 
 == ChangeLog ==
 
+= 1.3.1 =
+- Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.
+
 = 1.3 =
 - Fixed an error occurring when using the `wp gf form notification create` command.
 


### PR DESCRIPTION
Closes #29 

This adds support for installing or updating to Gravity Forms beta releases. We are not supporting add-on betas with this release.

## Testing Instructions
- On a site with 2.4 run `wp gf update --version=beta`
- Find the beta is installed
- Run `wp plugin delete gravityforms`
- Run `wp gf install --version=beta --key=your_key_here`
- Find the beta is installed
- Run `wp gf install gravityformszapier --version=beta --key=your_key_here`
- Find the `--version=beta is not currently supported by add-ons.` error is output
- Run `wp gf install gravityforms-beta --key=your_key_here`
- Find the `Appending -beta to the slug is not supported. Use --version=beta instead.` error is output