### PR TITLE
Fix fatal error which can occur when using the version command with an add-on slug

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,6 @@
 = 1.3.1 =
 - Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.
+- Fixed a fatal error which can occur when using the `wp gf version` command with an add-on slug when Gravity Forms is not active or not installed.
 
 = 1.3 =
 - Fixed an error occurring when using the `wp gf form notification create` command.

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -29,14 +29,14 @@ class GF_CLI_Root extends WP_CLI_Command {
 	 *     wp gf version gravityformspolls
 	 */
 	public function version( $args, $assoc_args ) {
+		if ( ! class_exists( 'GFForms' ) ) {
+			WP_CLI::error( 'Gravity Forms is not installed. Use the wp gf install command.' );
+		}
+
 		$slug = $this->get_slug( $args );
 
 		if ( $slug == 'gravityforms' ) {
-			if ( class_exists( 'GFForms' ) ) {
-				WP_CLI::log( GFForms::$version );
-			} else {
-				WP_CLI::error( 'Gravity Forms is not installed. Use the wp gf install command.' );
-			}
+			WP_CLI::log( GFForms::$version );
 		} else {
 			$addon_class_names = GFAddOn::get_registered_addons();
 			$addon_found = false;

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,7 @@ If you have any ideas for improvements please submit your idea at https://www.gr
 
 = 1.3.1 =
 - Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.
+- Fixed a fatal error which can occur when using the `wp gf version` command with an add-on slug when Gravity Forms is not active or not installed.
 
 = 1.3 =
 - Fixed an error occurring when using the `wp gf form notification create` command.


### PR DESCRIPTION
This fixes a fatal error which occurs when Gravity Forms is not active and the version command is used with an add-on slug

## Testing Instructions
- Run `wp plugin deactivate gravityforms`
- Run `wp gf version gravityformsstripe`
- Find the `There has been a critical error on your website.Learn more about debugging in WordPress. There has been a critical error on your website.` error is output and there is a fatal error in the debug.log file
- Switch to this branch
- Repeat command to find the fatal error does not occur and the `Gravity Forms is not installed. Use the wp gf install command.` error is output