### PR TITLE
Fix update command using GF version for add-on slugs

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,7 @@
+= 1.3.2 =
+- Fixed an issue where the version comparison performed when using `wp gf update` with an add-on slug uses the Gravity Forms version number.
+
+
 = 1.3.1 =
 - Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.
 - Fixed a fatal error which can occur when using the `wp gf version` command with an add-on slug when Gravity Forms is not active or not installed.

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: https://gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.3.1
+Version: 1.3.2
 Author: Rocketgenius
 Author URI: https://gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.3.1' );
+define( 'GF_CLI_VERSION', '1.3.2' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -186,23 +186,31 @@ class GF_CLI_Root extends WP_CLI_Command {
 			WP_CLI::error( 'A valid license key must be saved in the settings or specified in the GF_LICENSE_KEY constant or the --key option.' );
 		}
 
+		if ( $slug === 'gravityforms' ) {
+			$current_version = GFForms::$version;
+		} else {
+			$addon           = $this->get_addon( $slug );
+			$current_version = $addon->get_version();
+		}
+
 		$version     = isset( $assoc_args['version'] ) ? $assoc_args['version'] : 'hotfix';
 		$plugin_info = $version === 'beta' ? $this->get_beta_plugin_info( $slug, $key ) : $this->get_plugin_info( $slug, $key );
 
 		if ( $version == 'hotfix' ) {
 			$available_version = isset( $plugin_info['version_latest'] ) ? $plugin_info['version_latest'] : '';
-			$download_url = isset( $plugin_info['download_url_latest'] ) ? $plugin_info['download_url_latest'] : '';
+			$download_url      = isset( $plugin_info['download_url_latest'] ) ? $plugin_info['download_url_latest'] : '';
 		} else {
 			$available_version = isset( $plugin_info['version'] ) ? $plugin_info['version'] : '';
-			$download_url = isset( $plugin_info['download_url'] ) ? $plugin_info['download_url'] : '';
-		}
-
-		if ( version_compare( GFForms::$version, $available_version, '>=' ) ) {
-			WP_CLI::success( 'Plugin already updated' );
-			return;
+			$download_url      = isset( $plugin_info['download_url'] ) ? $plugin_info['download_url'] : '';
 		}
 
 		if ( $plugin_info && ! empty( $download_url ) ) {
+
+			if ( version_compare( $current_version, $available_version, '>=' ) ) {
+				WP_CLI::success( 'Plugin already updated' );
+
+				return;
+			}
 
 			$download_url .= '&key=' . $key;
 

--- a/readme.txt
+++ b/readme.txt
@@ -185,6 +185,9 @@ If you have any ideas for improvements please submit your idea at https://www.gr
 
 == ChangeLog ==
 
+= 1.3.2 =
+- Fixed an issue where the version comparison performed when using `wp gf update` with an add-on slug uses the Gravity Forms version number.
+
 = 1.3.1 =
 - Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.
 - Fixed a fatal error which can occur when using the `wp gf version` command with an add-on slug when Gravity Forms is not active or not installed.


### PR DESCRIPTION
This fixes an issue where the Gravity Forms version number is used instead of the add-on version number when the update command checks if the plugin has already been updated.

`GF_CLI_Root::get_addon()` has been added to get the current instance of the add-on for the given slug.

## Testing Instructions
- Edit the version number in advancedpostcreation.php so it is older than the latest build e.g. 1.0-beta-4
- Run `wp gf update gravityformsadvancedpostcreation`
- Find the `Plugin already updated` success message is output
- Note this is incorrect as the latest version is 1.0-beta-5
- Switch to this branch
- Repeat command
- Find the latest version of the add-on is downloaded and installed
- Run `wp gf version gravityformsadvancedpostcreation` to confirm the correct version is output
- Run `wp plugin deactivate gravityformsadvancedpostcreation`
- Run `wp gf update gravityformsadvancedpostcreation`
- Find the `Invalid slug or plugin not active: gravityformsadvancedpostcreation` error message is output