### PR TITLE
Update type to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gravityforms/gravityformscli",
   "description": "A set of WP-CLI commands to manage Gravity Forms.",
-  "type": "wp-cli-package",
+  "type": "wordpress-plugin",
   "homepage": "https://github.com/gravityforms/gravityformscli",
   "support": {
     "issues": "https://gravityforms.com"


### PR DESCRIPTION
### Description 

This PR fixes gravityforms/backlog#386 by updating the package type to wordpress-plugin


### Testing Instructions

1. Outside of your WordPress installation, in another directory, create a `composer.json` file with the following contents:
```
{
	"repositories": [
		{
			"type": "git",
			"url": "git@github.com:gravityforms/gravityformscli.git"
		}
	],
	"require": {
		"composer/installers": "^1.11",
		"gravityforms/gravityformscli": "^1.4"
	}
}
```
2. Run `composer install`.
3. Review the contents of the directory. You should see a `composer.lock` file and a `vendor` directory. The vendor directory should contain a directory named `gravityforms`, which itself contains a directory named `gravityformscli`, which contains the contents of this repository.
4. Run `rm --rf vendor composer.lock` in the command line.
5. Run `composer require gravityforms/gravityformscli:dev-fix-386-package-type`.
6. Review your directory contents again. You should now have a `vendor` directory and a `wp-content` directory. The `wp-content` directory should contain the `gravityformscli` package within the `plugins` directory.

