### PR TITLE
Allow usage as wp cli package

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,6 @@
+= 1.5 =
+- Updated the plugin to allow its usage as a WP-CLI package.
+
 = 1.4 =
 - Fixed an issue where the version comparison performed when using `wp gf update` with an add-on slug uses the Gravity Forms version number.
 - Added support for using `--version=beta` with the `wp gf install` and `wp gf update` commands. Add-On beta releases are not currently supported.

--- a/class-gf-cli.php
+++ b/class-gf-cli.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 // Include the Gravity Forms add-on framework
 GFForms::include_addon_framework();

--- a/cli.php
+++ b/cli.php
@@ -69,7 +69,7 @@ class GF_CLI_Bootstrap {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 			// Checks for files within the includes directory, and includes them.
-			foreach ( glob( plugin_dir_path( __FILE__ ) . 'includes/*.php' ) as $filename ) {
+			foreach ( glob( dirname( __FILE__ ) . '/includes/*.php' ) as $filename ) {
 				require_once( $filename );
 			}
 			$command_args = array( 'before_invoke' => array( 'GF_CLI_Bootstrap', 'before_invoke' ) );

--- a/cli.php
+++ b/cli.php
@@ -27,7 +27,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see http://www.gnu.org/licenses.
 */
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 // Defines the current version of the CLI add-on
 define( 'GF_CLI_VERSION', '1.4' );

--- a/cli.php
+++ b/cli.php
@@ -37,7 +37,7 @@ define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 add_action( 'init', array( 'GF_CLI_Bootstrap', 'load_cli' ), 1 );
 
 // After GF is loaded, load the CLI add-on
-add_action( 'gform_loaded', array( 'GF_CLI_Bootstrap', 'load_addon' ), 1 );
+defined( 'ABSPATH' ) && add_action( 'gform_loaded', array( 'GF_CLI_Bootstrap', 'load_addon' ), 1 );
 
 
 

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: https://gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.4
+Version: 1.5
 Author: Rocketgenius
 Author URI: https://gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.4' );
+define( 'GF_CLI_VERSION', '1.5' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/cli.php
+++ b/cli.php
@@ -34,8 +34,6 @@ define( 'GF_CLI_VERSION', '1.4' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 
-add_action( 'init', array( 'GF_CLI_Bootstrap', 'load_cli' ), 1 );
-
 // After GF is loaded, load the CLI add-on
 defined( 'ABSPATH' ) && add_action( 'gform_loaded', array( 'GF_CLI_Bootstrap', 'load_addon' ), 1 );
 
@@ -100,6 +98,8 @@ class GF_CLI_Bootstrap {
 		}
 	}
 }
+
+GF_CLI_Bootstrap::load_cli();
 
 /**
  * Returns an instance of the GF_CLI class

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gravityforms/gravityformscli",
   "description": "A set of WP-CLI commands to manage Gravity Forms.",
-  "type": "wordpress-plugin",
+  "type": "wp-cli-package",
   "homepage": "https://github.com/gravityforms/gravityformscli",
   "support": {
     "issues": "https://gravityforms.com"

--- a/includes/class-gf-cli-entry-notification.php
+++ b/includes/class-gf-cli-entry-notification.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Send Gravity Forms Notifications.

--- a/includes/class-gf-cli-entry.php
+++ b/includes/class-gf-cli-entry.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Manage Gravity Forms Entries.

--- a/includes/class-gf-cli-form-field.php
+++ b/includes/class-gf-cli-form-field.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Manage Gravity Forms Form Fields.

--- a/includes/class-gf-cli-form-notification.php
+++ b/includes/class-gf-cli-form-notification.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Manage Gravity Forms Notifications.

--- a/includes/class-gf-cli-form.php
+++ b/includes/class-gf-cli-form.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Manage Gravity Forms.

--- a/includes/class-gf-cli-license.php
+++ b/includes/class-gf-cli-license.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Manage the Gravity Forms License Key.

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Manage Gravity Forms.

--- a/includes/class-gf-cli-tool.php
+++ b/includes/class-gf-cli-tool.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'ABSPATH' ) || die();
+defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 /**
  * Misc Gravity Forms Tools.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: rocketgenius, stevehenty
 Tags: gravity forms
 Requires at least: 4.2
-Tested up to: 5.8
+Tested up to: 6.4
 Stable tag: 1.4
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Description
This PR adds the ability to use the plugin as a global WP-CLI Package, to make all GF CLI commands available to any site installed on the server without the need of installing the plugin on each site.

Closes https://github.com/gravityforms/backlog/issues/3983
Closes https://github.com/gravityforms/backlog/issues/3039 by updating the "Tested up to" version


## Testing instructions

1. Download this branch as a ZIP file from Github, not the package built with HAL because it removes the `composer.json` file.
2. Using the command line, install the plugin as a global WP-CLI Package with this command: `wp package install <full path to the zip file>`
a. What location should I be at? installed from within local/site/app/public (site didn't have gravityforms repo) and it installed to /Users/gosiapado/.wpcli/packages/local/gravityforms-gravityformscli
4. Using the command line, change directory to a directory containing a WordPress site with Gravity Forms installed but NO gravityformscli installed.
a. What location should I be at? any directory that is child of the root directory (any child of the directory containing your wp-config.php file)
6. Try using a GF Cli command and confirm it works. For example, this should list all the forms: `wp gf form list`

Note: Once this PR is merged, users will be able to install this package directly from the public Git repository this way:
`wp package install https://github.com/gravityforms/gravityformscli.git`

[QA issue tracking sheet](https://docs.google.com/spreadsheets/d/1IgUai6QzMxuTv_5DbG93IewTT7ewhCZkQV9DkDjjc68/edit#gid=1735498910)

## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've checked the error log to ensure my code doesn't throw any errors.
- [X] I've added a changelog entry (if necessary) and updated the version number in 4 places, run `npm install` and committed package-lock.json (if necessary).
- [X] My code follows the WordPress coding standards and inline documentation standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ and https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] This PR has a related issue.
- [ ] This PR has a related test.
- [X] I have given QA direction on which areas are most important to test.
- [X] I have considered what will happen when an existing user updates to this branch.
- [X] I have added a "Documentation Needed" label to this PR (if necessary).
