### PR TITLE
Adds GravitySMTP Support to Update Command

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,6 @@
+= 1.6 =
+- Updated the plugin to support installing and updating Gravity SMTP.
+
 = 1.5 =
 - Updated the plugin to allow its usage as a WP-CLI package.
 

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: https://gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.5
+Version: 1.6
 Author: Rocketgenius
 Author URI: https://gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.5' );
+define( 'GF_CLI_VERSION', '1.6' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -188,6 +188,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 		if ( $slug === 'gravityforms' ) {
 			$current_version = GFForms::$version;
+		} elseif ( $slug === 'gravitysmtp' ) {
+			$current_version = GF_GRAVITY_SMTP_VERSION;
 		} else {
 			$addon           = $this->get_addon( $slug );
 			$current_version = $addon->get_version();
@@ -276,6 +278,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 					WP_CLI::error( 'Use the --force flag to force the database setup.' );
 				}
 			}
+		} elseif ( $slug ==='gravitysmtp' ) {
+			WP_CLI::success( 'setup gravitysmtp' );
 		} else {
 			$addon = $this->get_addon( $slug );
 			$addon->setup();

--- a/includes/class-gf-cli-root.php
+++ b/includes/class-gf-cli-root.php
@@ -37,6 +37,8 @@ class GF_CLI_Root extends WP_CLI_Command {
 
 		if ( $slug == 'gravityforms' ) {
 			WP_CLI::log( GFForms::$version );
+		} elseif ( $slug === 'gravitysmtp' ) {
+			$current_version = defined( 'GF_GRAVITY_SMTP_VERSION' ) ? GF_GRAVITY_SMTP_VERSION : null;
 		} else {
 			$addon = $this->get_addon( $slug );
 			WP_CLI::log( $addon->get_version() );
@@ -189,7 +191,7 @@ class GF_CLI_Root extends WP_CLI_Command {
 		if ( $slug === 'gravityforms' ) {
 			$current_version = GFForms::$version;
 		} elseif ( $slug === 'gravitysmtp' ) {
-			$current_version = GF_GRAVITY_SMTP_VERSION;
+			$current_version = defined( 'GF_GRAVITY_SMTP_VERSION' ) ? GF_GRAVITY_SMTP_VERSION : null;
 		} else {
 			$addon           = $this->get_addon( $slug );
 			$current_version = $addon->get_version();


### PR DESCRIPTION
## Description
This change updates our CLI tool to work for updating GravitySMTP. At this time, we just hardcoded a check for SMTP specifically, but as more new products come out we're going to want to look into updating this to be more general-purpose.

Addresses: https://github.com/gravityforms/backlog/issues/5337

## Testing Instructions
- Start a fresh site and install/enable this plugin
- Use `wp gf install gravityforms --key={your_key}` and `wp gf install gravitysmtp --key={your_key}` to install both plugins
- Go to the Plugins page and enable each plugin
- Manually edit the version in `gravitysmtp.php` to be a lower version
- Run `wp gf update gravitysmtp --key={your_key}`
- Ensure that the update works correctly and your plugin is fully updated