### PR TITLE
Prevent the form ID from being saved as a string

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,6 @@
+= 1.7 =
+- Fixed a bug that sometimes causes the form ID to be stored as a string.
+
 = 1.6 =
 - Updated the plugin to support installing and updating Gravity SMTP.
 

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: https://gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.6
+Version: 1.7
 Author: Rocketgenius
 Author URI: https://gravityforms.com
 License: GPL-2.0+
@@ -11,7 +11,7 @@ Text Domain: gravityformscli
 Domain Path: /languages
 
 ------------------------------------------------------------------------
-Copyright 2016-2020 Rocketgenius, Inc.
+Copyright 2016-2024 Rocketgenius, Inc.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.6' );
+define( 'GF_CLI_VERSION', '1.7' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-form.php
+++ b/includes/class-gf-cli-form.php
@@ -511,7 +511,7 @@ class GF_CLI_Form extends WP_CLI_Command {
 	 */
 	function update( $args, $assoc_args ) {
 
-		$form_id = $args[0];
+		$form_id = intval( $args[0] );
 
 		if ( isset( $assoc_args['form-json'] ) ) {
 			$json_config = $assoc_args['form-json'];

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: rocketgenius
 Tags: gravity forms
 Requires at least: 4.2
-Tested up to: 6.4
-Stable tag: 1.5
+Tested up to: 6.7
+Stable tag: 1.7
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -184,6 +184,12 @@ or
 1.  Go to the Plugin management page of WordPress admin section and enable the 'Gravity Forms CLI' plugin
 
 == ChangeLog ==
+= 1.7 =
+- Fixed a bug that sometimes causes the form ID to be stored as a string.
+
+= 1.6 =
+- Updated the plugin to support installing and updating Gravity SMTP.
+
 = 1.5 =
 - Updated the plugin to allow its usage as a WP-CLI package.
 


### PR DESCRIPTION
## Description
When you use the CLI to edit a form, the form ID gets saved as a string, which can have unintended consequences. This PR ensures that the form ID is an integer.

Closes https://github.com/gravityforms/backlog/issues/5523

## Testing instructions
1. Before testing, make sure that your computer's default command-line text editor is Nano: https://unix.stackexchange.com/a/657860
2. To see the problem on `master`, first make sure you know the ID of one of your forms, then in the command line type `wp gf form edit <FORMID>`
3. Make a small change to the form, such as changing the form title
4. Save and exit
5. In the database, go to the gf_form_meta table, and find the form you just edited.  Look at the form display meta, and you will see the form ID is a string wrapped in quotes
6. Now switch to this branch
7. Repeat steps 2-5, but this time you will see that the form ID is an integer not wrapped in quotes


#### QA Tracking Spreadsheet
<!-- QA crew to add a link to the spreadsheet for this PR created from the template. -->

## Screenshots <!-- if applicable -->
[screencast](https://share.gravityfor.ms/v/ByTXCz)

## Checklist:
- [x] I've checked the error log to ensure my code doesn't throw any errors.
- [x] I've added a changelog entry (if necessary) and updated the version number in 4 places, run `npm install` and committed package-lock.json (if necessary).
- [x] My code follows the WordPress coding standards and inline documentation standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ and https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] This PR has a related issue.
- [ ] This PR has a related test.
- [x] I have given QA direction on which areas are most important to test.
- [x] I have considered what will happen when an existing user updates to this branch.
- [ ] I have added a "Documentation Needed" label to this PR (if necessary).
