### PR TITLE
Extract checksums regardless of length and account for `sha1` encryption.

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,6 @@
+= 1.8 =
+- Fixed a bug where the verify checksums command fails even when it should succeed.
+
 = 1.7 =
 - Fixed a bug that sometimes causes the form ID to be stored as a string.
 

--- a/cli.php
+++ b/cli.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms CLI
 Plugin URI: https://gravityforms.com
 Description: Manage Gravity Forms with the WP CLI.
-Version: 1.7
+Version: 1.8
 Author: Rocketgenius
 Author URI: https://gravityforms.com
 License: GPL-2.0+
@@ -30,7 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.
 defined( 'ABSPATH' ) || defined( 'WP_CLI' ) || die();
 
 // Defines the current version of the CLI add-on
-define( 'GF_CLI_VERSION', '1.7' );
+define( 'GF_CLI_VERSION', '1.8' );
 
 define( 'GF_CLI_MIN_GF_VERSION', '1.9.17.8' );
 

--- a/includes/class-gf-cli-tool.php
+++ b/includes/class-gf-cli-tool.php
@@ -82,16 +82,20 @@ class GF_CLI_Tool extends WP_CLI_Command {
 
 		$has_errors = false;
 		foreach ( $checksums as $checksum_string ) {
-			$checksum = substr( $checksum_string, 0, 32 );
-			$file     = str_replace( $checksum . '  ', '', $checksum_string );
+			list( $checksum, $file ) = explode( '  ', $checksum_string );
 			$path     = GFCommon::get_base_path() . DIRECTORY_SEPARATOR . $file;
 			if ( ! file_exists( $path ) ) {
 				WP_CLI::warning( "File doesn't exist: {$file}" );
 				$has_errors = true;
 				continue;
 			}
-			$md5_file = md5_file( $path );
-			if ( $md5_file !== $checksum ) {
+			$hashed_file = '';
+			if ( strlen( $checksum ) === 32 ) {
+				$hashed_file = md5_file( $path );
+			} elseif ( strlen( $checksum) === 40 )  {
+				$hashed_file = sha1_file( $path );
+			}
+			if ( $hashed_file !== $checksum ) {
 				WP_CLI::warning( "File doesn't verify against checksum: {$file}" );
 				$has_errors = true;
 			}

--- a/includes/class-gf-cli-tool.php
+++ b/includes/class-gf-cli-tool.php
@@ -92,7 +92,7 @@ class GF_CLI_Tool extends WP_CLI_Command {
 			$hashed_file = '';
 			if ( strlen( $checksum ) === 32 ) {
 				$hashed_file = md5_file( $path );
-			} elseif ( strlen( $checksum) === 40 )  {
+			} elseif ( strlen( $checksum ) === 40 )  {
 				$hashed_file = sha1_file( $path );
 			}
 			if ( $hashed_file !== $checksum ) {


### PR DESCRIPTION
### Description

This issue resolves gravityforms/backlog#5741 by doing the following:
1. Updates how the checksum is extracted from the checksum string regardless of the checksum string length.
2. Depending on the length, it decides the encryption method used to generate the checksums and use when checking the files against the checksums.

### Testing instructions

1. Download the latest gravityforms build from gravityform.com (don't use the repo, we need that downloadable version in particular)
2. Use this branch for gravitycli 
3. Make sure gravity cli is activated 
4. From local, right click on the website and from the menu click "open site shell"
5. In the terminal type `cd app/public/wp-content/plugins/gravityforms`
6. Then type this command `wp gf tool verify-checksums`
7. After the command has been executed (it takes a couple of seconds) you should get the following success message :"Success: Gravity Forms install verifies against checksums."

[QA issue tracking sheet](https://docs.google.com/spreadsheets/d/16N8Zt6MuArS4yC7R3VNJS1Lvz0t4A4MuXBp_NVnlBeM/edit?gid=1735498910#gid=1735498910)